### PR TITLE
feat: migrate SDK release automation to release-please (off Stainless)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+name: release-please
+
+# Opens/maintains the "release: x.y.z" PR (version bump + CHANGELOG) and, on its
+# merge, tags the release. Replaces the release-please that Stainless ran externally
+# via the stainless-app GitHub App (which is being retired). Config + manifest already
+# live in the repo (release-please-config.json / .release-please-manifest.json).
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      # PAT (not GITHUB_TOKEN) so the release tag/event can trigger downstream
+      # publish workflows; GITHUB_TOKEN-created tags don't.
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        with:
+          token: ${{ secrets.PRODUCTION_REPO_TOKEN }}


### PR DESCRIPTION
Adds our in-house release-please workflow (uses the `PRODUCTION_REPO_TOKEN` org secret), replacing Stainless's external release automation. First release cut by this workflow will be **0.39.0** (the SDK content already landed via #113). Part of the ENG-2597 Stainless cutover.